### PR TITLE
Fix python dependencies by pinning some specific versions.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "python.formatting.provider": "black",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:runtime": "yarn vite build --config vite-runtime.config.ts",
     "build": "yarn build:packages && yarn build:app && yarn build:runtime",
     "generate-types": "pushd . && cd python && ./generate.sh && popd",
-    "generate-tray": "ts-node scripts/pyright_tray_generate.ts",
+    "generate-tray": "node --loader ts-node/esm scripts/pyright_tray_generate.ts",
     "test": "yarn jest"
   },
   "license": "BUSL-1.1",

--- a/packages/language-python/tray/pandas.json
+++ b/packages/language-python/tray/pandas.json
@@ -690,6 +690,31 @@
       }
     },
     {
+      "key": "pandas.Float64Index",
+      "abstract": "",
+      "serializedNode": {
+        "type": "PYTHON_CALL_MEMBER",
+        "properties": {
+          "member": "Float64Index"
+        },
+        "meta": {
+          "params": []
+        },
+        "childSets": {
+          "object": [
+            {
+              "type": "PY_IDENTIFIER",
+              "properties": {
+                "identifier": "pandas"
+              },
+              "childSets": {}
+            }
+          ],
+          "arguments": []
+        }
+      }
+    },
+    {
       "key": "pandas.Grouper",
       "abstract": "    A Grouper allows the user to specify a groupby instruction for an object.",
       "serializedNode": {
@@ -895,6 +920,31 @@
         "type": "PYTHON_CALL_MEMBER",
         "properties": {
           "member": "Int64Dtype"
+        },
+        "meta": {
+          "params": []
+        },
+        "childSets": {
+          "object": [
+            {
+              "type": "PY_IDENTIFIER",
+              "properties": {
+                "identifier": "pandas"
+              },
+              "childSets": {}
+            }
+          ],
+          "arguments": []
+        }
+      }
+    },
+    {
+      "key": "pandas.Int64Index",
+      "abstract": "",
+      "serializedNode": {
+        "type": "PYTHON_CALL_MEMBER",
+        "properties": {
+          "member": "Int64Index"
         },
         "meta": {
           "params": []
@@ -1674,6 +1724,31 @@
         "type": "PYTHON_CALL_MEMBER",
         "properties": {
           "member": "UInt64Dtype"
+        },
+        "meta": {
+          "params": []
+        },
+        "childSets": {
+          "object": [
+            {
+              "type": "PY_IDENTIFIER",
+              "properties": {
+                "identifier": "pandas"
+              },
+              "childSets": {}
+            }
+          ],
+          "arguments": []
+        }
+      }
+    },
+    {
+      "key": "pandas.UInt64Index",
+      "abstract": "",
+      "serializedNode": {
+        "type": "PYTHON_CALL_MEMBER",
+        "properties": {
+          "member": "UInt64Index"
         },
         "meta": {
           "params": []
@@ -2705,8 +2780,7 @@
             "path",
             "columns",
             "use_threads",
-            "storage_options",
-            "dtype_backend"
+            "storage_options"
           ]
         },
         "childSets": {
@@ -2848,8 +2922,7 @@
         "meta": {
           "params": [
             "path",
-            "columns",
-            "dtype_backend"
+            "columns"
           ]
         },
         "childSets": {
@@ -2986,8 +3059,7 @@
           "params": [
             "path",
             "usecols",
-            "convert_categoricals",
-            "dtype_backend"
+            "convert_categoricals"
           ]
         },
         "childSets": {

--- a/packages/language-python/tray/requests.json
+++ b/packages/language-python/tray/requests.json
@@ -785,6 +785,31 @@
       }
     },
     {
+      "key": "requests.NullHandler",
+      "abstract": "    This handler does nothing. It's intended to be used to avoid the",
+      "serializedNode": {
+        "type": "PYTHON_CALL_MEMBER",
+        "properties": {
+          "member": "NullHandler"
+        },
+        "meta": {
+          "params": []
+        },
+        "childSets": {
+          "object": [
+            {
+              "type": "PY_IDENTIFIER",
+              "properties": {
+                "identifier": "requests"
+              },
+              "childSets": {}
+            }
+          ],
+          "arguments": []
+        }
+      }
+    },
+    {
       "key": "requests.check_compatibility",
       "abstract": "",
       "serializedNode": {

--- a/packages/runtime-python/src/pyodide.ts
+++ b/packages/runtime-python/src/pyodide.ts
@@ -30,7 +30,7 @@ export async function setupPyodide(urls: string[]) {
   const micropip = pyodide.pyimport('micropip')
   const promises = [
     ...urls.map((url) => micropip.install(url)),
-    micropip.install('types-requests'),
+    micropip.install('types-requests==2.28.1'),
     micropip.install('ast-comments'),
   ]
 
@@ -47,7 +47,7 @@ export const loadDependencies = async (pyodide: any, newDependencies: Dependency
       let types = []
 
       if (name === 'pandas') {
-        types = ['pandas-stubs']
+        types = ['pandas-stubs~=1.5.3']
       } else if (name === 'streamlit') {
         return [urls.pyarrowPackageURL, urls.streamlitPackageURL]
       } else if (name === 'requests') {

--- a/scripts/pyright_tray_generate.ts
+++ b/scripts/pyright_tray_generate.ts
@@ -259,6 +259,7 @@ async function generateTrayListForModule(
   moduleName: string,
   isStandardLib: boolean
 ): Promise<PythonModuleInfo> {
+  console.log('Generating tray list for ' + moduleName)
   let id = 1
   const moduleNameNode: ModuleNameNode = {
     nodeType: ParseNodeType.ModuleName,
@@ -389,6 +390,8 @@ async function generateTrayListForModule(
 
   // Write to a file
   fs.writeFileSync('./packages/language-python/tray/' + moduleName + '.json', JSON.stringify(trayCategory, null, 2))
+  // Wait a bit for dev server to cope
+  await new Promise((resolve) => setTimeout(resolve, 200))
 
   return moduleInfo
 }

--- a/scripts/pyright_tray_generate.ts
+++ b/scripts/pyright_tray_generate.ts
@@ -222,12 +222,13 @@ async function main() {
   const micropip = pyodide.pyimport('micropip')
   await micropip.install(RequestsURL)
   await micropip.install(StreamlitURL)
+
   const promises = [
-    micropip.install('types-requests'),
-    micropip.install('numpy'),
-    micropip.install('pandas'),
-    micropip.install('pandas-stubs'),
-    micropip.install('flask'),
+    micropip.install('types-requests==2.28.1'),
+    micropip.install('numpy==1.23.5'),
+    micropip.install('pandas==1.5.2'),
+    micropip.install('pandas-stubs~=1.5.3'),
+    micropip.install('flask==2.3.3'),
   ]
   await Promise.all(promises)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6056,10 +6056,29 @@ ts-jest@^28.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-node@^10.8.1, ts-node@^10.9.1:
+ts-node@^10.8.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"


### PR DESCRIPTION
Some of the Python packages we use have released new versions in recent months. Unless we specify the version, it'll try to download and use the latest one and some of the other packages we have special versions of (like requests) are incompatible with the latest versions. I chose some specific versions that work together. 👍

Also fixed a couple of other things that mean the tray-generation wasn't working correctly all the time.